### PR TITLE
反向 WebSocket 支持使用 `Sec-WebSocket-Protocol` 头传递 `X-OneBot-Version` 和 `X-Impl`

### DIFF
--- a/specs/connect/communication/http-webhook.md
+++ b/specs/connect/communication/http-webhook.md
@@ -18,9 +18,8 @@ OneBot 实现应该根据用户配置，在发生事件时，向指定的 `url` 
 OneBot 实现必须在请求时设置以下请求头：
 
 - `Content-Type: application/json`
-- `User-Agent`：具体的 UA 值可以由实现自行定义
-    - 例如 `User-Agent: OneBot/12 (qq) Go-LibOneBot/1.0.0`
-- `X-OneBot-Version: <onebot_version>`：`<onebot_version>` 应为实现的 OneBot 标准版本
+- `User-Agent`：具体的 UA 值可以由实现自行定义，如 `OneBot/12 (qq) Go-LibOneBot/1.0.0`
+- `X-OneBot-Version: <onebot_version>`：`<onebot_version>` 应为实现的 OneBot 标准版本，如 `12`
 - `X-Impl: <impl>`：`<impl>` 应为实现的名称，格式见 [术语表](../../glossary.md#onebot-onebot-implementation)
 
 如果配置了 `access_token` 且不为空字符串，则还应该设置：

--- a/specs/connect/communication/websocket-reverse.md
+++ b/specs/connect/communication/websocket-reverse.md
@@ -15,7 +15,18 @@ OneBot 实现应该根据用户配置，向指定的 `url` 发起 WebSocket 连�
 
 ## 请求头
 
-除了不需要 `Content-Type`，在请求连接时应设置和 [HTTP Webhook](http-webhook.md) 相同的请求头。
+OneBot 实现必须在请求连接时设置以下请求头：
+
+- `User-Agent`：具体的 UA 值可以由实现自行定义，如 `OneBot/12 (qq) Go-LibOneBot/1.0.0`
+- `Sec-WebSocket-Protocol: <onebot_version>.<impl>`：
+    - `<onebot_version>` 应为实现的 OneBot 标准版本，如 `12`
+    - `<impl>` 应为实现的名称，格式见 [术语表](../../glossary.md#onebot-onebot-implementation)
+
+如果配置了 `access_token` 且不为空字符串，则还应该设置：
+
+- `Authorization: Bearer <access_token>`
+
+这里 `<access_token>` 不需要对两边的空白字符进行裁剪。若无法设置此请求头，实现应通过 `access_token` URL query 参数来传递 `<access_token>`。
 
 ## 事件和动作
 


### PR DESCRIPTION
## 变更内容和动机

Fixes #204

## 检查清单

<!-- 请确保以下步骤均已完成 -->

- [x] 我已在本地通过 `mkdocs serve` 预览文档
- [x] 我对文档的修改符合 [OneBot 风格指南](https://github.com/botuniverse/onebot/tree/master/style-guide)

## 关联 RFC

#204