### PR TITLE
修正状态更新事件示例的错别字

### DIFF
--- a/specs/interface/meta/events.md
+++ b/specs/interface/meta/events.md
@@ -61,7 +61,7 @@
         "id": "b6e65187-5ac0-489c-b431-53078e9d2bbb",
         "time": 1632847927.599013,
         "type": "meta",
-        "detail_type": "heartbeat",
+        "detail_type": "status_update",
         "sub_type": "",
         "status": {
             "good": true,


### PR DESCRIPTION
## 变更内容和动机

状态更新事件的示例里 `detail_type` 写错了。

## 检查清单

<!-- 请确保以下步骤均已完成 -->

- [x] 我已在本地通过 `mkdocs serve` 预览文档
- [x] 我对文档的修改符合 [OneBot 风格指南](https://github.com/botuniverse/onebot/tree/master/style-guide)

## 关联 RFC

<!-- 如果此 PR 是对某 RFC 的实现，请在这里通过形如 #123 的形式给出链接 -->
