### PR TITLE
`upload_file_fragmented` 分片上传文件接口传输阶段移除 `size` 参数

### DIFF
--- a/specs/interface/file/actions.md
+++ b/specs/interface/file/actions.md
@@ -79,7 +79,6 @@
     `stage` | string | - | 上传阶段，必须为 `transfer`
     `file_id` | string | - | 准备阶段返回的文件 ID
     `offset` | int64 | - | 本次传输的文件偏移，单位：字节
-    `size` | int64 | - | 本次传输的文件大小，单位：字节
     `data` | bytes | - | 本次传输的文件数据
 
 === "响应数据"


### PR DESCRIPTION
Fixes #228 

## 变更内容和动机

请在这里简要描述此 PR 中的引入变更，并解释变更的动机。

## 检查清单

<!-- 请确保以下步骤均已完成 -->

- [x] 我已在本地通过 `mkdocs serve` 预览文档
- [x] 我对文档的修改符合 [OneBot 风格指南](https://github.com/botuniverse/onebot/tree/master/style-guide)

## 关联 RFC

<!-- 如果此 PR 是对某 RFC 的实现，请在这里通过形如 #123 的形式给出链接 -->
