### PR TITLE
修正 动作请求 章节中过时的例子

### DIFF
--- a/specs/connect/data-protocol/action-request.md
+++ b/specs/connect/data-protocol/action-request.md
@@ -41,7 +41,14 @@
     "params": {
         "detail_type": "private",
         "user_id": "123445667",
-        "message": "嗨～"
+        "message": [
+            {
+                "type": "text",
+                "data": {
+                    "text": "嗨～"
+                }
+            }
+        ]
     },
     "echo": "1234"
 }


### PR DESCRIPTION
## 变更内容和动机

在文档的[OneBot Connect - 动作请求 - 例子](https://12.onebot.dev/connect/data-protocol/action-request/#_2)章节的例子不符合当前V12版本标准强制要求消息段的标准，需要更新

## 检查清单

<!-- 请确保以下步骤均已完成 -->

- [x] 我已在本地通过 `mkdocs serve` 预览文档
- [x] 我对文档的修改符合 [OneBot 风格指南](https://github.com/botuniverse/onebot/tree/master/style-guide)

## 关联 RFC

不涉及
